### PR TITLE
Filter incompatible value out for openpyxl at srum_dump2.py and update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lazy-object-proxy==1.4.1
 libesedb-python==20181229
 mccabe==0.6.1
 openpyxl==2.6.2
-PySimpleGUI==4.1.0
+PySimpleGUI==4.11.0
 python-registry==1.3.1
 pywin32-ctypes==0.2.0
 six==1.12.0

--- a/srum_dump2.py
+++ b/srum_dump2.py
@@ -307,7 +307,10 @@ def format_output(val, eachformat, eachstyle, xls_sheet):
         val = val
     else:
         val = val
-    new_cell.value = val  
+    try:
+        new_cell.value = val
+    except:
+        new_cell.value = re.sub(r'[\000-\010]|[\013-\014]|[\016-\037]|[\x00-\x1f\x7f-\x9f]|[\uffff]',"",val)
     return new_cell
 
 


### PR DESCRIPTION
- PySimpleGUI 4.1.0 is no longer provided as pip package. Updated the version to the nearest one at requirements.txt.
- openpyxl crashes with some incompatible characters. Added the filter for avoiding it at srum_dump2.py.